### PR TITLE
V1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/result-image-and-description.md
+++ b/.github/ISSUE_TEMPLATE/result-image-and-description.md
@@ -13,5 +13,5 @@ image
 # 2. Author
 Designed by NAME on [YYYY-MM-DD]
 
-## 3. Description
+# 3. Description
 Description of result image that was generated with `arcLandscape`

--- a/.github/ISSUE_TEMPLATE/result-image-and-description.md
+++ b/.github/ISSUE_TEMPLATE/result-image-and-description.md
@@ -1,0 +1,17 @@
+---
+name: Result image and description
+about: Result image that was generated with "arcLandscape" and its description
+title: resultImage_arcLandscape
+labels: image
+assignees: YujiSODE
+
+---
+
+# 1. Image
+image
+
+# 2. Author
+Designed by NAME on [YYYY-MM-DD]
+
+## 3. Description
+Description of result image that was generated with `arcLandscape`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log 
 ## [Unreleased]
 
+## [1.0.1] - 2022-03-28
+## Changed
+- [`index_main.js`] lines 17-20 and 30-36: changed to add the upper limit of canvas size as 3000 
+
 ## Released: [1.0] - 2022-03-23
 ## [1.0] - 2022-03-23
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## [Unreleased]
 
 ## [1.0.1] - 2022-03-28
+## Fixed
+- [`index_main.js`] lines 68, 74 and 84: fixed duplicated variable for canvas access (`cvs` to `C`)
+
 ## Changed
 - [`index_main.js`] lines 17-20 and 30-36: changed to add the upper limit of canvas size as 3000 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log 
 ## [Unreleased]
 
+## Released: [1.0.1] - 2022-03-28
 ## [1.0.1] - 2022-03-28
 ## Fixed
 - [`index_main.js`] lines 68, 74 and 84: fixed duplicated variable for canvas access (`cvs` to `C`)

--- a/index_main.js
+++ b/index_main.js
@@ -65,13 +65,13 @@
 	//
 	//generating download link
 	LINKB.addEventListener('click',()=>{
-		let cvs=slf.getElementById('outputCvs'),url,time=new Date();
+		let url,time=new Date();
 			//reset download link
 			A.href='#';
 			A.download='#';
 			A.style='display:none;';
 			//
-			url=async ()=>await cvs.toDataURL();
+			url=async ()=>await C.toDataURL();
 			//
 			setTimeout(()=>{
 				//set download link
@@ -81,7 +81,7 @@
 					A.textContent=time.toTimeString();
 					//
 					//output filename:"AL<number>_TYPE<type|typeReverse><width>x<height>.png"
-					A.download=`AL${time.getTime()}_TYPE${TYPE}${!REVERSE.checked?'':'Reverse'}${cvs.width}x${cvs.height}.png`;
+					A.download=`AL${time.getTime()}_TYPE${TYPE}${!REVERSE.checked?'':'Reverse'}${C.width}x${C.height}.png`;
 					A.style='display:inline;';
 				});
 			},2000);

--- a/index_main.js
+++ b/index_main.js
@@ -14,7 +14,10 @@
 		REVERSE=slf.getElementById('reverseOrder'),
 		A=slf.getElementById('downloadPNG'),
 		INPUT=slf.getElementById('textInput'),
-		/* === === */
+		/* === canvas size inputs === */
+		WIDTH=slf.getElementById('cWidth'),
+		HEIGHT=slf.getElementById('cHeight'),
+		/* === buttons === */
 		CLEARB=slf.getElementById('clearB'),
 		LOADB_txt=slf.getElementById('loadB_txt'),
 		LOADB_hex=slf.getElementById('loadB_hex'),
@@ -24,8 +27,13 @@
 	//
 	//form event
 	slf.getElementById('arcLandscapeForm').addEventListener('change',()=>{
-		C.width=slf.getElementById('cWidth').value;
-		C.height=slf.getElementById('cHeight').value;
+		//
+		//the upper limit for canvas size: 3000
+		WIDTH.value=WIDTH.value>3000?3000:WIDTH.value;
+		HEIGHT.value=HEIGHT.value>3000?3000:HEIGHT.value;
+		//
+		C.width=WIDTH.value;
+		C.height=HEIGHT.value;
 		//
 		//overriding value of TYPE
 		TYPE=undefined;


### PR DESCRIPTION
## Released: [1.0.1] - 2022-03-28
## [1.0.1] - 2022-03-28
## Fixed
- [`index_main.js`] lines 68, 74 and 84: fixed duplicated variable for canvas access (`cvs` to `C`)

## Changed
- [`index_main.js`] lines 17-20 and 30-36: changed to add the upper limit of canvas size as 3000 